### PR TITLE
Feature: Validation Types for Validation Error Handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package xero
 import (
 	"io"
 	"net/http"
+	"net/url"
 )
 
 // The Authorizer interface defines  common interface for authorising Xero HTTP
@@ -21,6 +22,17 @@ type Client struct {
 
 // do calls the Xero API
 func (c *Client) do(method, urlStr string, body io.Reader) (*http.Response, error) {
+	switch method {
+	case http.MethodPost, http.MethodPut:
+		u, err := url.Parse(urlStr)
+		if err != nil {
+			return nil, err
+		}
+		v := u.Query()
+		v.Set("SummarizeErrors", "false")
+		u.RawQuery = v.Encode()
+		urlStr = u.String()
+	}
 	req, err := http.NewRequest(method, urlStr, body)
 	if err != nil {
 		return nil, err

--- a/validation.go
+++ b/validation.go
@@ -1,0 +1,84 @@
+package xero
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// Standard XML validation status response values from Xero
+const (
+	validationStatusOK    = "OK"
+	validationStatusError = "ERROR"
+)
+
+// Validation status values returned by Xero
+var (
+	ValidationStatusOK    = ValidationStatus{validationStatusOK}
+	ValidationStatusError = ValidationStatus{validationStatusError}
+)
+
+// The elementDecoder interface is used when handling decoding custom types
+// from xml strings to their actual types
+type elementDecoder interface {
+	DecodeElement(interface{}, *xml.StartElement) error
+}
+
+// The ValidationStatus type holds the validation status xml attribute, e.g:
+//   <Response>
+//       <Invoices>
+//           <Invoice status="OK">
+//               ...
+//           </Invoice>
+//           <Invoice status="ERROR">
+//               ...
+//           </Invoice>
+//       </Invoices>
+//   </Response>
+type ValidationStatus struct {
+	status string
+}
+
+// String implements the fmt.Stringer interface
+func (v ValidationStatus) String() string {
+	return v.status
+}
+
+// MarshalXMLAttr handles marshaling the validation status into an xml attribute
+func (v ValidationStatus) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	switch v {
+	case ValidationStatusOK, ValidationStatusError:
+		return xml.Attr{name, v.String()}, nil
+	default:
+		return xml.Attr{}, fmt.Errorf("invalid validation type: %s", v.String())
+	}
+}
+
+// UnmarshalXMLAttr handles unmarshaling the raw "status" xml attribute value into
+// a ValidatuoinStatus type
+func (v *ValidationStatus) UnmarshalXMLAttr(attr xml.Attr) error {
+	switch attr.Value {
+	case validationStatusOK:
+		*v = ValidationStatusOK
+	case validationStatusError:
+		*v = ValidationStatusError
+	default:
+		return fmt.Errorf("unknown validation status: %s", attr.Value)
+	}
+	return nil
+}
+
+// The Validation type is used for validating PUT/POST requests
+// to the Xero API. Each type, such as Invoice embeds this common
+// validation type which can be checked against in the response
+// from Xero for each type posted/put to the API
+// See the validation.go example
+type Validation struct {
+	Status ValidationStatus  `xml:"status,attr,omitempty"`
+	Errors []ValidationError `xml:"ValidationErrors>ValidationError,omitempty"`
+}
+
+// The ValidationError type holds a individual validation error
+// message from the Xero API
+type ValidationError struct {
+	Message string `xml:"Message"`
+}

--- a/validation.go
+++ b/validation.go
@@ -72,7 +72,7 @@ func (v *ValidationStatus) UnmarshalXMLAttr(attr xml.Attr) error {
 // validation type which can be checked against in the response
 // from Xero for each type posted/put to the API
 // See the validation.go example
-type Validation struct {
+type ValidationErrors struct {
 	Status ValidationStatus  `xml:"status,attr,omitempty"`
 	Errors []ValidationError `xml:"ValidationErrors>ValidationError,omitempty"`
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -1,0 +1,85 @@
+package xero
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidationStatus_MarshalXMLAttr(t *testing.T) {
+	type testcase struct {
+		tname         string
+		status        ValidationStatus
+		expectedXML   []byte
+		expectedError error
+	}
+	tt := []testcase{
+		testcase{
+			tname:         "invalid value",
+			status:        ValidationStatus{"foo"},
+			expectedError: errors.New("invalid validation type: foo"),
+		},
+		testcase{
+			tname:       "ok value",
+			status:      ValidationStatusOK,
+			expectedXML: []byte(`<Foo status="OK"></Foo>`),
+		},
+		testcase{
+			tname:       "error value",
+			status:      ValidationStatusError,
+			expectedXML: []byte(`<Foo status="ERROR"></Foo>`),
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.tname, func(t *testing.T) {
+			body := struct {
+				XMLName xml.Name         `xml:"Foo"`
+				Status  ValidationStatus `xml:"status,attr"`
+			}{
+				Status: tc.status,
+			}
+			b, err := xml.Marshal(&body)
+			assert.Equal(t, tc.expectedError, err)
+			assert.Equal(t, tc.expectedXML, b)
+		})
+	}
+}
+
+func TestValidationStatus_UnmarshalXMLAttr(t *testing.T) {
+	type testcase struct {
+		tname          string
+		xml            []byte
+		expectedError  error
+		expectedStatus ValidationStatus
+	}
+	tt := []testcase{
+		testcase{
+			tname:         "invalid value",
+			xml:           []byte(`<foo status="BAR"></foo>`),
+			expectedError: fmt.Errorf("unknown validation status: BAR"),
+		},
+		testcase{
+			tname:          "ok value",
+			xml:            []byte(`<foo status="OK"></foo>`),
+			expectedStatus: ValidationStatusOK,
+		},
+		testcase{
+			tname:          "error value",
+			xml:            []byte(`<foo status="ERROR"></foo>`),
+			expectedStatus: ValidationStatusError,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.tname, func(t *testing.T) {
+			body := struct {
+				Status ValidationStatus `xml:"status,attr"`
+			}{}
+			err := xml.Unmarshal(tc.xml, &body)
+			assert.Equal(t, tc.expectedStatus, body.Status)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -103,30 +103,30 @@ func TestValidation(t *testing.T) {
 	body := struct {
 		XMLName xml.Name `xml:"Response"`
 		Foos    []struct {
-			Validation
+			ValidationErrors
 			Name string `xml:"Name"`
 		} `xml:"Foos>Foo"`
 	}{}
 	expected := struct {
 		XMLName xml.Name `xml:"Response"`
 		Foos    []struct {
-			Validation
+			ValidationErrors
 			Name string `xml:"Name"`
 		} `xml:"Foos>Foo"`
 	}{
 		XMLName: xml.Name{Local: "Response"},
 		Foos: []struct {
-			Validation
+			ValidationErrors
 			Name string `xml:"Name"`
 		}{
 			{
-				Validation: Validation{
+				ValidationErrors: ValidationErrors{
 					Status: ValidationStatusOK,
 				},
 				Name: "Foo",
 			},
 			{
-				Validation: Validation{
+				ValidationErrors: ValidationErrors{
 					Status: ValidationStatusError,
 					Errors: []ValidationError{
 						ValidationError{"you forgot something"},


### PR DESCRIPTION
This PR implements new types for handling validation errors from Xero on `POST` and `PUT` requests.

An example response looks like this

``` xml
<Response>
  <Foos>
    <Foo status="ERROR">
      <ValidationErrors>
        <ValidationError>
          <Message>you forgot something</Message>
        </ValidationError>
      </ValidationErrors>
    </Foo>
  </Foos>
</Response>
```

The `ValidationErrors` type can be embedded into any time so the XML response from Xero can be processed.

For example:

``` go
type Foos struct {
    Foos []Foo `xml:"Foos>Foo"`
}

type Foo struct {
    ValidationErrors

    Name string `xml:"Name"`
}
```

The `TestValidation` test case shows how this works.