### PR TITLE
Feature: Contact Iterator

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%  # we always want at least 90% coverage here

--- a/address.go
+++ b/address.go
@@ -40,7 +40,7 @@ func (a *AddressType) MarshalXML(encoder *xml.Encoder, start xml.StartElement) e
 }
 
 // unmarshalXML handles converting raw Xero Payment Term XML data into valid Payment Term
-func (a *AddressType) unmarshalXML(decoder decoder, start xml.StartElement) error {
+func (a *AddressType) unmarshalXML(decoder elementDecoder, start xml.StartElement) error {
 	var value string
 	if err := decoder.DecodeElement(&value, &start); err != nil {
 		return err

--- a/address_test.go
+++ b/address_test.go
@@ -51,14 +51,14 @@ func TestAddressType_MarshalXML(t *testing.T) {
 func TestAddressType_unmarshalXML(t *testing.T) {
 	type testcase struct {
 		tname               string
-		decoder             func(t *testing.T) decoder
+		decoder             func(t *testing.T) elementDecoder
 		expectedAddressType AddressType
 		expectedErr         error
 	}
 	tt := []testcase{
 		testcase{
 			tname: "decoder error",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					return errors.New("decoder error")
 				}}
@@ -67,7 +67,7 @@ func TestAddressType_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "invalid address type",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString("foo")
@@ -78,7 +78,7 @@ func TestAddressType_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "POBOX",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(addressTypePOBox)
@@ -89,7 +89,7 @@ func TestAddressType_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "STREET",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(addressTypeStreet)
@@ -100,7 +100,7 @@ func TestAddressType_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "DELIVERY",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(addressTypeDelivery)

--- a/authorizers/go-oauth/go-oauth.go
+++ b/authorizers/go-oauth/go-oauth.go
@@ -45,7 +45,11 @@ func (a *Authorizer) AuthorizeRequest(req *http.Request) error {
 		req.Header,
 		&client.Credentials,
 		req.Method,
-		req.URL,
+		&url.URL{
+			Scheme: req.URL.Scheme,
+			Host:   req.URL.Host,
+			Path:   req.URL.Path,
+		},
 		req.URL.Query())
 }
 

--- a/client.go
+++ b/client.go
@@ -40,18 +40,19 @@ type Response struct {
 type Client struct {
 	authorizer Authorizer
 	client     *http.Client
+
+	scheme string // Xero API Protocol Scheme (https)
+	host   string // Xero API Host (api.xero.com)
+	root   string // Xero API Root (/api.xro/2.0)
 }
 
 // url constructs a valid Xero API url. The scheme, host and api root are
 // automatically appended to the url path
-func (c *Client) url(endpoint string, values url.Values) *url.URL {
-	scheme := "https"      // TODO: configurable
-	host := "api.xero.com" // TODO: configurable
+func (c *Client) url(endpoint string) *url.URL {
 	return &url.URL{
-		Scheme:   scheme,
-		Host:     host,
-		Path:     path.Join(apiRoot, endpoint),
-		RawQuery: values.Encode(),
+		Scheme: c.scheme,
+		Host:   c.host,
+		Path:   path.Join(c.root, endpoint),
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -9,8 +9,21 @@ import (
 	"time"
 )
 
-// Xero API 2.0 Root Path
-const apiRoot = "/api.xro/2.0"
+// Internal interface tyes implemented by the Client type
+type (
+	// The getter interface is implemented by the Client type and used internally
+	getter interface {
+		Get(string) (*http.Response, error)
+	}
+	// The poster interface is implemented by the Client type and used internally
+	poster interface {
+		Post(string, io.Reader) (*http.Response, error)
+	}
+	// The putter interface is implemented by the Client type and used internally
+	putter interface {
+		Put(string, io.Reader) (*http.Response, error)
+	}
+)
 
 // The Authorizer interface defines  common interface for authorising Xero HTTP
 // requests using oAuth. The AuthorizeRequest takes the HTTP request that requires

--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testGetter func(string) (*http.Response, error)
+
+func (fn testGetter) Get(urlStr string) (*http.Response, error) {
+	return fn(urlStr)
+}
+
 type testAuthorizer struct {
 	err error
 }

--- a/contacts.go
+++ b/contacts.go
@@ -211,11 +211,11 @@ func (c ContactIterator) Next() (ContactIterator, []Contact, error) {
 	if err != nil {
 		return c, nil, err
 	}
+	defer rsp.Body.Close()
 	decoder := NewDecoder(rsp.Body)
 	if err := decoder.Decode(&dst); err != nil {
 		return c, nil, err
 	}
-	defer rsp.Body.Close()
 	if len(dst.Contacts) == 0 {
 		return c, nil, io.EOF
 	}

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -2,6 +2,7 @@ package xero
 
 import (
 	"encoding/xml"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -49,11 +50,19 @@ func TestContactIterator_url(t *testing.T) {
 func TestContactIterator_Next(t *testing.T) {
 	type testcase struct {
 		tname            string
+		getter           testGetter
 		ts               func(t *testing.T) (*httptest.Server, *url.URL)
 		expectedContacts []Contact
 		expectedErr      error
 	}
 	tt := []testcase{
+		testcase{
+			tname: "request error",
+			getter: testGetter(func(string) (*http.Response, error) {
+				return nil, errors.New("request error")
+			}),
+			expectedErr: errors.New("request error"),
+		},
 		testcase{
 			tname: "bad xml",
 			ts: func(t *testing.T) (*httptest.Server, *url.URL) {

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -1,6 +1,7 @@
 package xero
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,11 @@ func TestContactIterator_url(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.tname, func(t *testing.T) {
-			i := ContactIterator{tc.page, &Client{}}
+			i := ContactIterator{tc.page, &Client{}, &url.URL{
+				Scheme:  "https",
+				Host:    "api.xero.com",
+				RawPath: "/api.xero/2.0",
+			}}
 			assert.Equal(t, tc.expectedURL, i.url())
 		})
 	}

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -1,1 +1,38 @@
 package xero
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContactIterator_url(t *testing.T) {
+	type testcase struct {
+		tname       string
+		page        int
+		expectedURL string
+	}
+	tt := []testcase{
+		testcase{
+			tname:       "page 1",
+			page:        1,
+			expectedURL: "https://api.xero.com/api.xro/2.0/Contacts?page=1",
+		},
+		testcase{
+			tname:       "page 2",
+			page:        2,
+			expectedURL: "https://api.xero.com/api.xro/2.0/Contacts?page=2",
+		},
+		testcase{
+			tname:       "page 3",
+			page:        3,
+			expectedURL: "https://api.xero.com/api.xro/2.0/Contacts?page=3",
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.tname, func(t *testing.T) {
+			i := ContactIterator{tc.page, &Client{}}
+			assert.Equal(t, tc.expectedURL, i.url())
+		})
+	}
+}

--- a/contacts_test.go
+++ b/contacts_test.go
@@ -1,0 +1,1 @@
+package xero

--- a/date.go
+++ b/date.go
@@ -22,7 +22,7 @@ func (d UTCDate) MarshalXML(encoder *xml.Encoder, start xml.StartElement) error 
 }
 
 // unmarshalXML handles converting raw Xero UTC Date XML data into valid time
-func (d *UTCDate) unmarshalXML(decoder decoder, start xml.StartElement) error {
+func (d *UTCDate) unmarshalXML(decoder elementDecoder, start xml.StartElement) error {
 	var value string
 	if err := decoder.DecodeElement(&value, &start); err != nil {
 		return err

--- a/date.go
+++ b/date.go
@@ -7,7 +7,7 @@ import (
 
 // Xero date time layouts
 const (
-	utcDateLayout = "2006-01-02T15:04:05.000"
+	utcDateLayout = "2006-01-02T15:04:05"
 )
 
 // The UTCDate type is used for storing Xero UTC date field values

--- a/date_test.go
+++ b/date_test.go
@@ -43,14 +43,14 @@ func TestUTCDate_MarshalXML(t *testing.T) {
 func TestUTCDate_unmarshalXML(t *testing.T) {
 	type testcase struct {
 		tname           string
-		decoder         func(t *testing.T) decoder
+		decoder         func(t *testing.T) elementDecoder
 		expectedUTCDate UTCDate
 		expectedErr     error
 	}
 	tt := []testcase{
 		testcase{
 			tname: "decoder error",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					return errors.New("decoder error")
 				}}
@@ -59,7 +59,7 @@ func TestUTCDate_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "time parse error",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					v = "foo" // Invalid format
 					return nil
@@ -69,7 +69,7 @@ func TestUTCDate_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "ok",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString("2009-05-14T01:44:26.747")

--- a/doc_test.go
+++ b/doc_test.go
@@ -1,6 +1,8 @@
 package xero_test
 
 import (
+	"fmt"
+	"io"
 	"log"
 	"os"
 
@@ -24,4 +26,24 @@ func Example() {
 	}
 	defer rsp.Body.Close()
 	log.Println(rsp.StatusCode)
+}
+
+func ExampleClient_Contacts() {
+	f, err := os.Open("/path/to/privatekey.pem")
+	if err != nil {
+		log.Fatal(err)
+	}
+	pk, err := xero.PrivateKey(f)
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := xero.New(oauth.New("TOKEN", pk))
+	for i, contacts, err := client.Contacts(); err != io.EOF; i, contacts, err = i.Next() {
+		if err != nil {
+			log.Fatal(err)
+		}
+		for i := range contacts {
+			fmt.Println(contacts[i].Name)
+		}
+	}
 }

--- a/encoding.go
+++ b/encoding.go
@@ -1,7 +1,43 @@
 package xero
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"io"
+)
 
-type decoder interface {
+// elementDecoder defines an interface implementd by xml.Decoder
+type elementDecoder interface {
 	DecodeElement(v interface{}, start *xml.StartElement) error
 }
+
+// Interfaces encoders and decoders must implement
+type (
+	Encoder interface {
+		Encode(v interface{}) error
+	}
+	Decoder interface {
+		Decode(v interface{}) error
+	}
+)
+
+// Func types for consutructing new Encoders and Decoders
+type (
+	NewDecoderFn func(r io.Reader) Decoder
+	NewEncoderFn func(w io.Writer) Encoder
+)
+
+// Default Decoder is JSON
+var defaultNewDecoder = func(r io.Reader) Decoder {
+	return xml.NewDecoder(r)
+}
+
+// Set the global NewDecoder to use default new decoder
+var NewDecoder NewDecoderFn = defaultNewDecoder
+
+// Default Encoder is JSON
+var defaultNewEncoder = func(w io.Writer) Encoder {
+	return xml.NewEncoder(w)
+}
+
+// Set the global NewEncoder to use default new encoder
+var NewEncoder NewEncoderFn = defaultNewEncoder

--- a/examples/contacts/README.md
+++ b/examples/contacts/README.md
@@ -1,0 +1,10 @@
+# Contacts Example
+
+This example shows the basics of making an iterative paginated call to the `/Contacts`
+Xero API endpoont to return a list of `Contact`'s
+
+```
+$ go get github.com/thisissoon/go-xero
+$ go get github.com/thisissoon/go-xero/authorizers/go-oauth
+$ go run examples/contacts/main.go -pemfile=/path/to.pem -token=TOKEN
+```

--- a/examples/contacts/main.go
+++ b/examples/contacts/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	xero "github.com/thisissoon/go-xero"
+	xauth "github.com/thisissoon/go-xero/authorizers/go-oauth"
+)
+
+func main() {
+	pemfile := flag.String("pemfile", "", "Xero API PEM file location")
+	token := flag.String("token", "", "Xero API Token")
+	flag.Parse()
+	f, err := os.Open(*pemfile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	pk, err := xero.PrivateKey(f)
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := xero.New(xauth.New(*token, pk))
+	for i, contacts, err := client.Contacts(); err != io.EOF; i, contacts, err = i.Next() {
+		if err != nil {
+			log.Fatal(err)
+		}
+		for i := range contacts {
+			fmt.Println(contacts[i].Name)
+		}
+	}
+}

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -6,5 +6,5 @@ the most basic use of the package.
 ```
 $ go get github.com/thisissoon/go-xero
 $ go get github.com/thisissoon/go-xero/authorizers/go-oauth
-$ go run examples/simple.go -pemfile=/path/to/privatekey.pem -token=TOKEN
+$ go run examples/simple/main.go -pemfile=/path/to/privatekey.pem -token=TOKEN
 ```

--- a/payment_terms.go
+++ b/payment_terms.go
@@ -39,7 +39,7 @@ func (pt *PaymentTerm) MarshalXML(encoder *xml.Encoder, start xml.StartElement) 
 }
 
 // unmarshalXML handles converting raw Xero Payment Term XML data into valid Payment Term
-func (pt *PaymentTerm) unmarshalXML(decoder decoder, start xml.StartElement) error {
+func (pt *PaymentTerm) unmarshalXML(decoder elementDecoder, start xml.StartElement) error {
 	var value string
 	if err := decoder.DecodeElement(&value, &start); err != nil {
 		return err

--- a/payment_terms_test.go
+++ b/payment_terms_test.go
@@ -56,14 +56,14 @@ func TestPaymentTerm_MarshalXML(t *testing.T) {
 func TestPaymentTerm_unmarshalXML(t *testing.T) {
 	type testcase struct {
 		tname               string
-		decoder             func(t *testing.T) decoder
+		decoder             func(t *testing.T) elementDecoder
 		expectedPaymentTerm PaymentTerm
 		expectedErr         error
 	}
 	tt := []testcase{
 		testcase{
 			tname: "decoder error",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					return errors.New("decoder error")
 				}}
@@ -72,7 +72,7 @@ func TestPaymentTerm_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "invalid payment term",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString("foo")
@@ -83,7 +83,7 @@ func TestPaymentTerm_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "DAYSAFTERBILLDATE",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(paymentTermDaysAfterBillDate)
@@ -94,7 +94,7 @@ func TestPaymentTerm_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "DAYSAFTERBILLMONTH",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(paymentTermSaysAfterBillMonth)
@@ -105,7 +105,7 @@ func TestPaymentTerm_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "OFCURRENTMONTH",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(paymentTermOfCurrentMonth)
@@ -116,7 +116,7 @@ func TestPaymentTerm_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "OFFOLLOWINGMONTH",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(paymentTermOfFollowingMonth)

--- a/phones.go
+++ b/phones.go
@@ -43,7 +43,7 @@ func (pt *PhoneType) MarshalXML(encoder *xml.Encoder, start xml.StartElement) er
 }
 
 // unmarshalXML handles converting raw Xero Payment Term XML data into valid Payment Term
-func (pt *PhoneType) unmarshalXML(decoder decoder, start xml.StartElement) error {
+func (pt *PhoneType) unmarshalXML(decoder elementDecoder, start xml.StartElement) error {
 	var value string
 	if err := decoder.DecodeElement(&value, &start); err != nil {
 		return err

--- a/phones_test.go
+++ b/phones_test.go
@@ -56,14 +56,14 @@ func TestPhoneType_MarshalXML(t *testing.T) {
 func TestPhoneType_unmarshalXML(t *testing.T) {
 	type testcase struct {
 		tname             string
-		decoder           func(t *testing.T) decoder
+		decoder           func(t *testing.T) elementDecoder
 		expectedPhoneType PhoneType
 		expectedErr       error
 	}
 	tt := []testcase{
 		testcase{
 			tname: "decoder error",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					return errors.New("decoder error")
 				}}
@@ -72,7 +72,7 @@ func TestPhoneType_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "invalid phone type",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString("foo")
@@ -83,7 +83,7 @@ func TestPhoneType_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "DEFAULT",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(phoneTypeDefault)
@@ -94,7 +94,7 @@ func TestPhoneType_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "DDI",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(phoneTypeDDI)
@@ -105,7 +105,7 @@ func TestPhoneType_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "MOBILE",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(phoneTypeMobile)
@@ -116,7 +116,7 @@ func TestPhoneType_unmarshalXML(t *testing.T) {
 		},
 		testcase{
 			tname: "FAX",
-			decoder: func(t *testing.T) decoder {
+			decoder: func(t *testing.T) elementDecoder {
 				return &testDecoder{t: t, fn: func(t *testing.T, v interface{}, s *xml.StartElement) error {
 					val := reflect.ValueOf(v).Elem()
 					val.SetString(phoneTypeFax)

--- a/validation.go
+++ b/validation.go
@@ -17,12 +17,6 @@ var (
 	ValidationStatusError = ValidationStatus{validationStatusError}
 )
 
-// The elementDecoder interface is used when handling decoding custom types
-// from xml strings to their actual types
-type elementDecoder interface {
-	DecodeElement(interface{}, *xml.StartElement) error
-}
-
 // The ValidationStatus type holds the validation status xml attribute, e.g:
 //   <Response>
 //       <Invoices>

--- a/xero.go
+++ b/xero.go
@@ -13,6 +13,9 @@ import (
 func New(authorizer Authorizer) *Client {
 	return &Client{
 		authorizer: authorizer,
+		scheme:     "https",
+		host:       "api.xero.com",
+		root:       "/api.xro/2.0",
 	}
 }
 

--- a/xero_test.go
+++ b/xero_test.go
@@ -96,6 +96,9 @@ func TestNew(t *testing.T) {
 			fakeAuthorizer{},
 			&Client{
 				authorizer: fakeAuthorizer{},
+				scheme:     "https",
+				host:       "api.xero.com",
+				root:       "/api.xro/2.0",
 			},
 		},
 	}


### PR DESCRIPTION
This PR implements a `ContactIerator` to enable users to iterate of n number of contacts in batches of 100.

Example usage:

``` go
package main

import (
	"flag"
	"fmt"
	"io"
	"log"
	"os"

	xero "github.com/thisissoon/go-xero"
	xauth "github.com/thisissoon/go-xero/authorizers/go-oauth"
)

func main() {
	pemfile := flag.String("pemfile", "", "Xero API PEM file location")
	token := flag.String("token", "", "Xero API Token")
	flag.Parse()
	f, err := os.Open(*pemfile)
	if err != nil {
		log.Fatal(err)
	}
	pk, err := xero.PrivateKey(f)
	if err != nil {
		log.Fatal(err)
	}
	client := xero.New(xauth.New(*token, pk))
	for i, contacts, err := client.Contacts(); err != io.EOF; i, contacts, err = i.Next() {
		if err != nil {
			log.Fatal(err)
		}
		for i := range contacts {
			fmt.Println(contacts[i].Name)
		}
	}
}
```