### PR TITLE
Feature: Bank transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ func main() {
 - [ ] Accounts (@jamesjwarren)
   - [x] `GET`
   - [ ] `DELETE`
-- [ ] Bank Transactions (@jamesjwarren)
+- [x] Bank Transactions (@jamesjwarren)
   - [x] `GET`
-- [ ] Bank Transfer
-  - [ ] `GET`
+- [x] Bank Transfer (@jamesjwarren)
+  - [x] `GET`
 - [ ] Branding Themes
   - [ ] `GET`
 - [ ] Contacts (@krak3n)

--- a/bank_transactions.go
+++ b/bank_transactions.go
@@ -152,6 +152,7 @@ func (c *Client) BankTransactions() (BankTransactionIterator, []BankTransaction,
 type BankAccount struct {
 	Code      string `xml:"Code,omitempty"`
 	AccountID string `xml:"AccountID,omitempty"`
+	Name      string `xml:"Name,omitempty"`
 }
 
 // The LineItem type represents a single line item in Xero

--- a/bank_transfer.go
+++ b/bank_transfer.go
@@ -1,0 +1,89 @@
+package xero
+
+import (
+	"fmt"
+	"io"
+)
+
+// BankTransfer API Root
+const apiBankTransferRoot = "/BankTransfers"
+
+// BankTransfersEndpoint defines the Xero bank transfers endpoint
+var BankTransfersEndpoint = Endpoint(apiBankTransferRoot)
+
+// The BankTransfer type represents a single bank transfer within Xero.
+//    <BankTransfer>
+//      <BankTransferID>d79f3e07-5f11-45e4-9d1a-30be536d0e13</BankTransferID>
+//      <CreatedDateUTC>2014-02-25T19:27:15</CreatedDateUTC>
+//      <Date>2014-02-26T00:00:00</Date>
+//      <FromBankAccount>
+//        <AccountID>ac993f75-035b-433c-82e0-7b7a2d40802c</AccountID>
+//        <Name>Business Bank Account</Name>
+//      </FromBankAccount>
+//      <ToBankAccount>
+//        <AccountID>ebd06280-af70-4bed-97c6-7451a454ad85</AccountID>
+//        <Name>Business Savings Account</Name>
+//      </ToBankAccount>
+//      <Amount>20.00</Amount>
+//      <FromBankTransactionID>b11794bc-775b-4f78-9b28-8f13240082ff</FromBankTransactionID>
+//      <ToBankTransactionID>f589fb5e-34b3-4392-8207-4ba5a093eae</ToBankTransactionID>
+//    </BankTransfer>
+type BankTransfer struct {
+	ValidationErrors // Used for validating POST/PUT requests
+
+	// The following can be set on POST/PUT requests
+	FromBankAccount BankAccount `xml:"FromBankAccount,omitempty"`
+	ToBankAccount   BankAccount `xml:"ToBankAccount,omitempty"`
+	Amount          float64     `xml:"Amount,omitempty"`
+	Date            UTCDate     `xml:"Date,omitempty"`
+	// The following are only retrieved on GET requests
+	BankTransferID        string  `xml:"BankTransferID,omitempty"`
+	CurrencyRate          float32 `xml:"CurrencyRate,omitempty"`
+	FromBankTransactionID string  `xml:"FromBankTransactionID,omitempty"`
+	ToBankTransactionID   string  `xml:"ToBankTransactionID,omitempty"`
+	HasAttachments        bool    `xml:"HasAttachments,omitempty"`
+	CreatedDateUTC        UTCDate `xml:"CreatedDateUTC,omitempty"`
+}
+
+func (c BankTransfer) Encode(dst io.Writer) error {
+	return encode(dst, &c)
+}
+
+type BankTransfers struct {
+	BankTransfers []BankTransfer `xml:"BankTransfers>BankTransfer"`
+}
+
+func (c BankTransfers) Encode(dst io.Writer) error {
+	return encode(dst, &c)
+}
+
+type BankTransfersResponse struct {
+	Response
+	BankTransfers
+}
+
+// BankTransfer returns a specific singular banke transfer from the Xero API
+// Identifier can be the Xero identifier for a transfer e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9
+func (c *Client) BankTransfer(identifier string) (BankTransfer, error) {
+	var dst BankTransfersResponse
+	var transfer BankTransfer
+	urlStr := c.url(BankTransfersEndpoint, identifier).String()
+	if err := c.get(urlStr, &dst); err != nil {
+		return transfer, err
+	}
+	if len(dst.BankTransfers.BankTransfers) == 0 {
+		return transfer, fmt.Errorf("transfer %s not found", identifier)
+	}
+	transfer = dst.BankTransfers.BankTransfers[0]
+	return transfer, nil
+}
+
+// BankTransfers returns a list of BankTransfers from the /BankTransfers endpoint
+func (c *Client) BankTransfers() ([]BankTransfer, error) {
+	var dst BankTransfersResponse
+	urlStr := c.url(AccountsEndpoint).String()
+	if err := c.get(urlStr, &dst); err != nil {
+		return []BankTransfer{}, err
+	}
+	return dst.BankTransfers.BankTransfers, nil
+}

--- a/bank_transfer_test.go
+++ b/bank_transfer_test.go
@@ -1,0 +1,148 @@
+package xero
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_BankTransfers(t *testing.T) {
+	type testcase struct {
+		tname             string
+		ts                func(t *testing.T) (*httptest.Server, *url.URL)
+		expectedTransfers []BankTransfer
+		expectedErr       error
+	}
+	tt := []testcase{
+		testcase{
+			tname: "bad xml",
+			ts: func(t *testing.T) (*httptest.Server, *url.URL) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`</uwotm8>`))
+				}))
+				u, err := url.Parse(ts.URL)
+				assert.NoError(t, err)
+				return ts, u
+			},
+			expectedErr:       &xml.SyntaxError{Msg: "unexpected end element </uwotm8>", Line: 1},
+			expectedTransfers: []BankTransfer{},
+		},
+		testcase{
+			tname: "transfers returned",
+			ts: func(t *testing.T) (*httptest.Server, *url.URL) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`<Response>
+						<BankTransfers>
+							<BankTransfer>
+								<Amount>20.00</Amount>
+							</BankTransfer>
+							<BankTransfer>
+								<Amount>20.00</Amount>
+							</BankTransfer>
+						</BankTransfers>
+					</Response>`))
+				}))
+				u, err := url.Parse(ts.URL)
+				assert.NoError(t, err)
+				return ts, u
+			},
+			expectedTransfers: []BankTransfer{
+				{Amount: 20},
+				{Amount: 20},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.tname, func(t *testing.T) {
+			ts, u := tc.ts(t)
+			defer ts.Close()
+			c := &Client{
+				authorizer: new(testAuthorizer),
+				scheme:     u.Scheme,
+				host:       u.Host,
+				root:       u.Path,
+			}
+			transfers, err := c.BankTransfers()
+			assert.Equal(t, tc.expectedTransfers, transfers)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}
+
+func TestClient_BankTransfer(t *testing.T) {
+	type testcase struct {
+		tname            string
+		ts               func(t *testing.T) (*httptest.Server, *url.URL)
+		expectedTransfer BankTransfer
+		expectedErr      error
+	}
+	tt := []testcase{
+		testcase{
+			tname: "bad xml",
+			ts: func(t *testing.T) (*httptest.Server, *url.URL) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`</uwotm8>`))
+				}))
+				u, err := url.Parse(ts.URL)
+				assert.NoError(t, err)
+				return ts, u
+			},
+			expectedErr: &xml.SyntaxError{Msg: "unexpected end element </uwotm8>", Line: 1},
+		},
+		testcase{
+			tname: "0 transfers",
+			ts: func(t *testing.T) (*httptest.Server, *url.URL) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`<Response><BankTransfers></BankTransfers></Response>`))
+				}))
+				u, err := url.Parse(ts.URL)
+				assert.NoError(t, err)
+				return ts, u
+			},
+			expectedErr: fmt.Errorf("transfer %s not found", "foo"),
+		},
+		testcase{
+			tname: "transfer returned",
+			ts: func(t *testing.T) (*httptest.Server, *url.URL) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`<Response>
+						<BankTransfers>
+							<BankTransfer>
+								<Amount>20.00</Amount>
+							</BankTransfer>
+						</BankTransfers>
+					</Response>`))
+				}))
+				u, err := url.Parse(ts.URL)
+				assert.NoError(t, err)
+				return ts, u
+			},
+			expectedTransfer: BankTransfer{Amount: 20},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.tname, func(t *testing.T) {
+			ts, u := tc.ts(t)
+			defer ts.Close()
+			c := &Client{
+				authorizer: new(testAuthorizer),
+				scheme:     u.Scheme,
+				host:       u.Host,
+				root:       u.Path,
+			}
+			transfer, err := c.BankTransfer("foo")
+			assert.Equal(t, tc.expectedTransfer, transfer)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}


### PR DESCRIPTION
Adds the BankTransfer type and the following client methods:
- `client.BankTransfer("foo")` GET single transfer
- `client.BankTransfers()` GET non-paginated slice of transfers